### PR TITLE
Exercise 5 fix null response

### DIFF
--- a/backend/src/neo4jSchema.js
+++ b/backend/src/neo4jSchema.js
@@ -1,0 +1,27 @@
+import { gql } from "apollo-server";
+import { makeAugmentedSchema } from "neo4j-graphql-js";
+import neo4j from "neo4j-driver";
+
+export const driver = neo4j.driver(
+    "neo4j://localhost:7687",
+    neo4j.auth.basic(process.env.NEO4J_USER, process.env.NEO4J_PASSWORD)
+);
+
+const typeDefs = gql`
+    type Post {
+        id: ID!
+        title: String!
+        votes: Int!
+        author: User! @relation(name: "WROTE", direction: "IN")
+    }
+
+    type User {
+        id: ID!
+        name: String!
+        email: String!
+        posts: [Post] @relation(name: "WROTE", direction: "OUT")
+    }
+`;
+
+const schema = makeAugmentedSchema({ typeDefs });
+export default schema;

--- a/backend/src/resolvers.js
+++ b/backend/src/resolvers.js
@@ -13,7 +13,14 @@ const resolvers = ({ subschema }) => ({
                 context,
                 info,
             }),
-        posts: (_, args, context) => context.dataSources.db.allPosts(),
+        posts: (_, args, context, info) =>
+            delegateToSchema({
+                schema: subschema,
+                operation: "query",
+                fieldName: "Post",
+                context,
+                info,
+            }),
     },
     Mutation: {
         signup: async (_, args, context, info) => {

--- a/backend/src/typeDefs.js
+++ b/backend/src/typeDefs.js
@@ -1,20 +1,6 @@
 import { gql } from "apollo-server";
 
 const typeDefs = gql`
-    type Post {
-        id: ID!
-        title: String!
-        votes: Int!
-        author: User! @relation(name: "WROTE", direction: "IN")
-    }
-
-    type User {
-        id: ID!
-        name: String!
-        email: String!
-        posts: [Post] @relation(name: "WROTE", direction: "OUT")
-    }
-
     type Query {
         posts: [Post]
         users: [User]


### PR DESCRIPTION
@powlaa @noeljns I promised you I would have a look into your problem
with strange `null` responses for all queries and mutations generated by
`neo4j-graphql-js`. The problem was quickly found: You must give
`neo4j-graphql-js` a number of types. It will then generate the queries
and mutations for you. You should not put the same typeDefs in your
gateway schema.